### PR TITLE
Fix Expires header logic

### DIFF
--- a/lib/LWP/UserAgent/WithCache.pm
+++ b/lib/LWP/UserAgent/WithCache.pm
@@ -48,7 +48,7 @@ sub request {
 
      if ( defined $obj ) {
 
-         unless (defined $obj->{expires} and $obj->{expires} <= time()) {
+         if (defined $obj->{expires} and $obj->{expires} > time()) {
              return HTTP::Response->parse($obj->{as_string});
          } 
 


### PR DESCRIPTION
This change better accounts for cases when the Expires header isn't set at all.
