### PR TITLE
Support 304 NOT MODIFIED Responses

### DIFF
--- a/lib/LWP/UserAgent/WithCache.pm
+++ b/lib/LWP/UserAgent/WithCache.pm
@@ -50,11 +50,10 @@ sub request {
 
          if (defined $obj->{expires} and $obj->{expires} > time()) {
              return HTTP::Response->parse($obj->{as_string});
-         } 
+         }
 
          if (defined $obj->{last_modified}) {
-             $request->header('If-Modified-Since' =>
-                              HTTP::Date::time2str($obj->{last_modified}));
+             $request->header('If-Modified-Since' => HTTP::Date::time2str($obj->{last_modified}));
          }
 
          if (defined $obj->{etag}) {
@@ -65,9 +64,17 @@ sub request {
      }
 
      my $res = $self->SUPER::request(@args);
-     $self->set_cache($uri, $res) if $res->code eq HTTP::Status::RC_OK;
-
-     return $res;
+     
+     if ($res->code eq HTTP::Status::RC_NOT_MODIFIED) {
+       $res = HTTP::Response->parse($obj->{as_string});
+       $self->set_cache($uri, $res);
+     }
+     
+     if ($res->code eq HTTP::Status::RC_OK) {
+       $self->set_cache($uri, $res);
+     }
+     
+     return $res;     
 }
 
 sub set_cache {


### PR DESCRIPTION
Original code only respected 200 responses as valid. This patch returns the existing cache if the response is a 304.
